### PR TITLE
Fixed card and img issues

### DIFF
--- a/client/src/components/ProductItem/index.js
+++ b/client/src/components/ProductItem/index.js
@@ -42,7 +42,7 @@ function ProductItem(item) {
   };
 
   return (
-    <div className="card  card shadow m-2">
+    <div className="card shadow m-2">
       <Link to={`/products/${_id}`} style={{ textDecoration: 'none' }}>
         <p className="p-country">{country}</p>
         <img alt={name} src={`/images/${image} `} style={imageStyle} />

--- a/client/src/components/ProductItem/productItem.css
+++ b/client/src/components/ProductItem/productItem.css
@@ -1,5 +1,5 @@
 .card {
-  width: 25%;
+  /* width: 25%; */
   text-align: center;
   padding: 0px;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -203,7 +203,7 @@ input:focus {
   color: var(--error);
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 1024px) {
   .card {
     width: 100%;
   }

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -154,7 +154,7 @@ function Dashboard() {
             >
               Booking History
             </h3>
-            {user.orders.map((order) => (
+            {user.orders.map((order) => (              
               <div
                 key={order._id}
                 className="m-3 p-3 rounded shadow rounded-3"
@@ -171,16 +171,23 @@ function Dashboard() {
                   {new Date(parseInt(order.purchaseDate)).toLocaleDateString()}
                 </h3>
                 <div className="flex-row justify-content-around">
-                  {order.products.map(({ _id, image, name, price }, index) => (
-                    <div key={index} className="card px-1 py-1">
-                      <Link to={`/products/${_id}`}>
-                        <img alt={name} src={`/images/${image}`} />
-                        <p>{name}</p>
-                      </Link>
-                      <div>
-                        <span>${price}</span>
-                      </div>
+                  {order.products.map(({ _id, image, name, price, country }, index) => (                    
+                  <div key={index} className="card shadow m-2 opacity-75">
+                    <div className="d-country">
+                      {country}
                     </div>
+                    <Link to={`/products/${_id}`} style={{ textDecoration: 'none' }}>
+                      <img
+                        style={imageStyle}
+                        alt={name}
+                        src={`/images/${image}`}
+                      />
+                      <p className="d-name">{name}</p>
+                    </Link>
+                    <div>
+                      <span className="d-price">${price}</span>
+                    </div>
+                  </div>
                   ))}
                 </div>
               </div>


### PR DESCRIPTION
The following 2 issues are closed now:
1. [Home page] When the window is small, cards are squished and the page is not transitioning to 1 column mode.
-  productItem.css .card {width: 25%} was overruling the styling in index.css @media screen ...
-  Now this productItem.css .card {width: 25%} is commented out
-  (This is additional) I also changed the max-width from 768 px to 1024px in index.css @media screen. We can change this later if we want.
2. [My Favourite page] Images are not within the card frame
- Dashboard.js line 180 <img> was missing style={imageStyle}